### PR TITLE
Make <h3> child a template string

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -91,8 +91,8 @@ class ImageCropDemo extends Component {
                     <Cropper src={src} ref="image3" disabled={true}/>
                 </li>
                 <li>
-                    <h3>Variable width and height, cropper frame is relative to natural image size, don't allow new
-                        selection, set custom styles</h3>
+                    <h3>{`Variable width and height, cropper frame is relative to natural image size, don't allow new
+                        selection, set custom styles`}</h3>
                     <Cropper src={src}
                              width={200}
                              height={500}


### PR DESCRIPTION
If you change line 94 to a template string it will not break github syntax highlighting.


<img width="1000" alt="screen shot 2017-05-25 at 12 08 51 pm" src="https://cloud.githubusercontent.com/assets/6667096/26461542/08c647ea-4143-11e7-9bcb-aa5e28104448.png">

